### PR TITLE
Fix name of function implementing hook_farm_map_view.

### DIFF
--- a/farm_map_no.farm_map.inc
+++ b/farm_map_no.farm_map.inc
@@ -18,6 +18,6 @@ function farm_map_no_farm_map_behaviors() {
 /**
  * Implements hook_farm_map_view().
  */
-function farm_farm_map_no_farm_map_view($name, $element) {
+function farm_map_no_farm_map_view($name, $element) {
   farm_map_add_behavior('farm_map_no');
 }


### PR DESCRIPTION
While testing out this module no additional layer was displaying in farmOS.. the `farmOS.map.behaviors.farm_map_no.js` file wasn't being loaded by the browser either.

Correcting this function name seemed to fix the problem.